### PR TITLE
Revert "fix: avoid `.bundle` extension"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default class PublishExtensionPlugin {
   makeBundle = async (directory) => {
     const options = {
       source: '*',
-      destination: resolve(directory, '-bundle.zip'),
+      destination: resolve(directory, '.bundle.zip'),
       cwd: directory,
     };
     await zip(options);


### PR DESCRIPTION
This reverts commit 08950fd6f26e88f1ba1565a5395d0dacd8153381.

I think I was mistaken and this is unnecessary.